### PR TITLE
Fix toggledIsOwnedVinyl method of client

### DIFF
--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,5 +1,4 @@
-import { Route, Routes } from "react-router";
-import { Navigate } from "react-router";
+import { Route, Routes, Navigate } from "react-router";
 import App from "../components/App/App";
 import NotFoundPAge from "../pages/NotFoundPage";
 import VinylsPage from "../vinyl/pages/VinylsPage/VinylsPage";

--- a/src/vinyl/client/VinylClient.ts
+++ b/src/vinyl/client/VinylClient.ts
@@ -36,9 +36,9 @@ class VinylClient implements VinylClientStructure {
     return vinylsCollectionData;
   };
 
-  public getVinylUpdate = async (vinylId: string): Promise<Vinyl> => {
+  public toggleIsOwnedVinyl = async (vinylId: string): Promise<Vinyl> => {
     const response = await fetch(
-      `${this.apiUrl}/vinyls/toggleOwner/${vinylId}`,
+      `${this.apiUrl}/vinyls/toggle-owned/${vinylId}`,
       { method: "PATCH", headers: { "Content-Type": "application/json" } },
     );
 

--- a/src/vinyl/client/__tests__/toggleIsOwnedVinyl.test.ts
+++ b/src/vinyl/client/__tests__/toggleIsOwnedVinyl.test.ts
@@ -14,7 +14,7 @@ describe("Given the getVinylUpdate method of VinylClietn", () => {
     test("Then it should return Minimal Nation that is not in the collection", async () => {
       const vinylClient = new VinylClient();
 
-      const vinylUpdate = await vinylClient.getVinylUpdate(
+      const vinylUpdate = await vinylClient.toggleIsOwnedVinyl(
         minimalNationDto._id,
       );
 
@@ -26,7 +26,7 @@ describe("Given the getVinylUpdate method of VinylClietn", () => {
     test("Then it should return El Círculo that is in the collection", async () => {
       const vinylClient = new VinylClient();
 
-      const vinylUpdate = await vinylClient.getVinylUpdate(
+      const vinylUpdate = await vinylClient.toggleIsOwnedVinyl(
         elCirculoNotOwned.id,
       );
 
@@ -43,7 +43,7 @@ describe("Given the getVinylUpdate method of VinylClietn", () => {
 
       server.use(
         http.patch(
-          `${apiUrl}/vinyls/toggleOwner/${aquellosOjosVerdes.id}`,
+          `${apiUrl}/vinyls/toggle-owned/${aquellosOjosVerdes.id}`,
           () => {
             return new HttpResponse(null, { status: 500 });
           },
@@ -52,7 +52,7 @@ describe("Given the getVinylUpdate method of VinylClietn", () => {
 
       const vinylClient = new VinylClient();
 
-      const vinylUpdate = vinylClient.getVinylUpdate(aquellosOjosVerdes.id);
+      const vinylUpdate = vinylClient.toggleIsOwnedVinyl(aquellosOjosVerdes.id);
 
       await expect(vinylUpdate).rejects.toThrow(expectedErrorMessage);
     });

--- a/src/vinyl/client/types.ts
+++ b/src/vinyl/client/types.ts
@@ -3,7 +3,7 @@ import type { VinylDto } from "../dto/types";
 
 export interface VinylClientStructure {
   getVinyls: (pageNumber?: number) => Promise<VinylsCollectionData>;
-  getVinylUpdate: (vinylId: string) => Promise<Vinyl>;
+  toggleIsOwnedVinyl: (vinylId: string) => Promise<Vinyl>;
 }
 
 export interface VinylsCollectionData {

--- a/src/vinyl/mocks/handlers.ts
+++ b/src/vinyl/mocks/handlers.ts
@@ -22,13 +22,13 @@ export const handlers = [
     });
   }),
 
-  http.patch(`${apiUrl}/vinyls/toggleOwner/${minimalNation.id}`, () => {
+  http.patch(`${apiUrl}/vinyls/toggle-owned/${minimalNation.id}`, () => {
     return HttpResponse.json<{ vinyl: VinylDto }>({
       vinyl: { ...minimalNationDto, isOwned: false },
     });
   }),
 
-  http.patch(`${apiUrl}/vinyls/toggleOwner/${elCirculoNotOwned.id}`, () => {
+  http.patch(`${apiUrl}/vinyls/toggle-owned/${elCirculoNotOwned.id}`, () => {
     return HttpResponse.json<{ vinyl: VinylDto }>({
       vinyl: { ...elCirculoDto, isOwned: true },
     });


### PR DESCRIPTION
Modified the name of the `getVinylUpdate` method to `toggleIsOwnedVinyl`.